### PR TITLE
Add support for self-hosted CLJS and simplify requiring macros in CLJS

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,10 @@
   :url "https://github.com/Provisdom/defn-spec"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/spec.alpha "0.1.143"]]
+  :dependencies [[org.clojure/clojure "1.10.0" :scope "provided"]
+                 [org.clojure/clojurescript "1.10.520" :scope "provided"]
+                 [org.clojure/spec.alpha "0.2.176"]
+                 [net.cgrand/macrovich "0.2.1"]]
   :deploy-repositories [["releases" "https://clojars.org/repo"]
                         ["snapshots" "https://clojars.org/repo"]]
   :test-selectors {:default    (complement :production)

--- a/src/defn_spec/core.cljc
+++ b/src/defn_spec/core.cljc
@@ -2,81 +2,83 @@
   (:require
     [clojure.spec.alpha :as s]
     [defn-spec.defn-args :as defn-args]
-    [clojure.spec.test.alpha :as st]))
+    [clojure.spec.test.alpha :as st]
+    #?(:clj [net.cgrand.macrovich :as macros]))
+  #?(:cljs
+     (:require-macros
+       [defn-spec.core]
+       [net.cgrand.macrovich :as macros])))
 
-(defn assert*
-  [kind fn-name spec x]
-  (if (s/valid? spec x)
-    x
-    (let [ed (merge (assoc (s/explain-data spec x)
-                      ::s/failure :assertion-failed))]
-      (throw (ex-info
-               (str
-                 (case kind
-                   :args (str "Call to "
-                              fn-name
-                              " did not conform to spec:")
-                   :ret (str "Return value from "
-                             fn-name
-                             " did not conform to spec:"))
-                 "\n"
-                 (with-out-str (s/explain-out ed)))
-               ed)))))
+(macros/usetime
+  (defn assert*
+    [kind fn-name spec x]
+    (if (s/valid? spec x)
+      x
+      (let [ed (merge (assoc (s/explain-data spec x)
+                        ::s/failure :assertion-failed))]
+        (throw (ex-info
+                 (str
+                   (case kind
+                     :args (str "Call to "
+                                fn-name
+                                " did not conform to spec:")
+                     :ret (str "Return value from "
+                               fn-name
+                               " did not conform to spec:"))
+                   "\n"
+                   (with-out-str (s/explain-out ed)))
+                 ed))))))
 
-#?(:clj
-   (defn qualify-symbol
-     [sym-name]
-     (symbol (str *ns*) (str sym-name))))
+(macros/deftime
+  (defn qualify-symbol
+    [sym-name]
+    (symbol (str *ns*) (str sym-name)))
 
-#?(:clj
-   (defn- defn-spec-form
-     [args]
-     (let [{:keys [name docstring meta bs]} (s/conform ::defn-args/defn-args args)
-           qualified-name (qualify-symbol name)
-           args-spec (or (::s/args meta) (:cljs.spec.alpha/args meta))
-           ret-spec (or (::s/ret meta) (:cljs.spec.alpha/ret meta))
-           body (let [[arity-type conformed-bodies] bs]
-                  (case arity-type
-                    :arity-1 (s/unform ::defn-args/args+body conformed-bodies)
-                    :arity-n (mapv (partial s/unform ::defn-args/args+body) (:bodies conformed-bodies))))
-           inner-fn-name (symbol (str name "-impl"))
-           args-sym (gensym "args")
-           result-sym (gensym "result")]
-       `(defn ~name
-          ~@(when docstring [docstring])
-          ~@(when meta [meta])
-          [& ~args-sym]
-          ~@(when args-spec [`(assert* :args '~qualified-name ~args-spec ~args-sym)])
-          (let [~result-sym (apply (fn ~inner-fn-name ~@body) ~args-sym)]
-            ~@(when ret-spec [`(assert* :ret '~qualified-name (s/spec ~ret-spec) ~result-sym)])
-            ~result-sym)))))
+  (defn- defn-spec-form
+    [args]
+    (let [{:keys [name docstring meta bs]} (s/conform ::defn-args/defn-args args)
+          qualified-name (qualify-symbol name)
+          args-spec (or (::s/args meta) (:cljs.spec.alpha/args meta))
+          ret-spec (or (::s/ret meta) (:cljs.spec.alpha/ret meta))
+          body (let [[arity-type conformed-bodies] bs]
+                 (case arity-type
+                   :arity-1 (s/unform ::defn-args/args+body conformed-bodies)
+                   :arity-n (mapv (partial s/unform ::defn-args/args+body) (:bodies conformed-bodies))))
+          inner-fn-name (symbol (str name "-impl"))
+          args-sym (gensym "args")
+          result-sym (gensym "result")]
+      `(defn ~name
+         ~@(when docstring [docstring])
+         ~@(when meta [meta])
+         [& ~args-sym]
+         ~@(when args-spec [`(assert* :args '~qualified-name ~args-spec ~args-sym)])
+         (let [~result-sym (apply (fn ~inner-fn-name ~@body) ~args-sym)]
+           ~@(when ret-spec [`(assert* :ret '~qualified-name (s/spec ~ret-spec) ~result-sym)])
+           ~result-sym))))
 
-#?(:clj
-   (defmacro defn-spec
-     "Exact same parameters as `defn`. You may optionally include `::s/args`
-     and/or `::s/ret` in your function's attr-map to have the args and/or return
-     value of your function checked with `s/assert`.
+  (defmacro defn-spec
+    "Exact same parameters as `defn`. You may optionally include `::s/args`
+    and/or `::s/ret` in your function's attr-map to have the args and/or return
+    value of your function checked with `s/assert`.
 
-     Setting `s/*compile-asserts*` to `false` will result in a regular function
-     definition."
-     {:arglists '([name doc-string? attr-map? [params*] prepost-map? body]
-                   [name doc-string? attr-map? ([params*] prepost-map? body) + attr-map?])}
-     [& args]
-     (if s/*compile-asserts*
-       (defn-spec-form args)
-       `(defn ~@args))))
+    Setting `s/*compile-asserts*` to `false` will result in a regular function
+    definition."
+    {:arglists '([name doc-string? attr-map? [params*] prepost-map? body]
+                  [name doc-string? attr-map? ([params*] prepost-map? body) + attr-map?])}
+    [& args]
+    (if s/*compile-asserts*
+      (defn-spec-form args)
+      `(defn ~@args)))
 
-#?(:clj
-   (s/fdef defn-spec
-           :args ::defn-args/defn-args
-           :ret any?))
+  (s/fdef defn-spec
+          :args ::defn-args/defn-args
+          :ret any?)
 
-#?(:clj
-   (defmacro fdef
-     "Exact same parameters as `s/fdef`. Automatically enables instrumentation
-     for `fn-sym` when `s/*compile-asserts*` is true."
-     [fn-sym & specs]
-     `(let [r# (s/fdef ~fn-sym ~@specs)]
-        ~@(when s/*compile-asserts*
-            [`(st/instrument '~(qualify-symbol fn-sym))])
-        r#)))
+  (defmacro fdef
+    "Exact same parameters as `s/fdef`. Automatically enables instrumentation
+    for `fn-sym` when `s/*compile-asserts*` is true."
+    [fn-sym & specs]
+    `(let [r# (s/fdef ~fn-sym ~@specs)]
+       ~@(when s/*compile-asserts*
+           [`(st/instrument '~(qualify-symbol fn-sym))])
+       r#)))


### PR DESCRIPTION
* Tested in Lumo v1.10.1 and Planck v2.22.0 by manually invoking examples from the readme in these REPLs:

```bash
lumo -c "$(lein classpath)" 

planck -c "$(lein classpath)"
```

Ideally, it should be unit tested (e.g. by using `lein-doo`). But it requires some more effort.

* Simplified the way macros can be required in ClojureScript. Before:

```clj
(ns foo.bar
  (:require [defn-spec.core :as ds :include-macros true]
```

after:

```clj
(ns foo.bar
  (:require [defn-spec.core :as ds]
```