### PR TITLE
Fix reference to clojure.spec keywords

### DIFF
--- a/src/defn_spec/core.cljc
+++ b/src/defn_spec/core.cljc
@@ -65,9 +65,9 @@
    (defn- defn-spec-form
      [args]
      (let [{:keys [name meta]} (s/conform ::defn-args args)
-           args-spec (::args meta)
-           ret-spec (::ret meta)
-           fn-spec (::fn meta)
+           args-spec (::s/args meta)
+           ret-spec (::s/ret meta)
+           fn-spec (::s/fn meta)
            fdef-sym (if (false? (::instrument? meta)) `s/fdef `fdef)]
        `(do
           (defn ~@args)


### PR DESCRIPTION
The main macroexpansion in this package wasn't working for me because
the keywords here weren't matching the clojure.spec.alpha in the `meta`
map.